### PR TITLE
Feature/itds-38 set spring security

### DIFF
--- a/src/main/java/com/dissonance/itit/common/annotation/CurrentUser.java
+++ b/src/main/java/com/dissonance/itit/common/annotation/CurrentUser.java
@@ -1,0 +1,16 @@
+package com.dissonance.itit.common.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal(expression = "getUser()")
+public @interface CurrentUser {
+}

--- a/src/main/java/com/dissonance/itit/common/jwt/filter/JwtAuthFilter.java
+++ b/src/main/java/com/dissonance/itit/common/jwt/filter/JwtAuthFilter.java
@@ -1,75 +1,55 @@
 package com.dissonance.itit.common.jwt.filter;
 
-import com.dissonance.itit.common.exception.ErrorCode;
-import com.dissonance.itit.common.exception.CustomException;
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
 import com.dissonance.itit.common.jwt.util.JwtUtil;
-import com.dissonance.itit.domain.entity.User;
-import com.dissonance.itit.repository.UserRepository;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.util.List;
 
 @RequiredArgsConstructor
 @Slf4j
 @Component
 public class JwtAuthFilter extends OncePerRequestFilter {
+	private final JwtUtil jwtUtil;
 
-    private final JwtUtil jwtUtil;
-    private final UserRepository userRepository;
+	@Override
+	protected void doFilterInternal(HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		String accessToken = resolveToken(request);
 
+		// 토큰 검사 생략
+		if (request.getServletPath().equals("/api/v1/reissue") || !StringUtils.hasText(accessToken)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
-        String accessToken = resolveToken(request);
+		if (jwtUtil.verifyToken(accessToken)) {
+			Authentication auth = jwtUtil.getAuthentication(accessToken);
+			SecurityContextHolder.getContext().setAuthentication(auth);
+		}
 
-        // 토큰 검사 생략
-        if (request.getServletPath().equals("/api/v1/reissue") || !StringUtils.hasText(accessToken)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+		filterChain.doFilter(request, response);
+	}
 
-        if (jwtUtil.verifyToken(accessToken)) {
-            // AccessToken의 payload에 있는 email로 user를 조회한다.
-            User findUser = userRepository.findByEmail(jwtUtil.getUid(accessToken))
-                    .orElseThrow(() -> new CustomException(ErrorCode.NON_EXISTENT_EMAIL));
+	private String resolveToken(HttpServletRequest httpServletRequest) {
+		String bearerToken = httpServletRequest.getHeader("Authorization");
 
-            // SecurityContext에 인증 객체를 등록한다.
-            Authentication auth = getAuthentication(findUser);
-            SecurityContextHolder.getContext().setAuthentication(auth);
-        }
+		if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+			return bearerToken.substring(7);
+		}
 
-        filterChain.doFilter(request, response);
-    }
-
-    // request Header에서 토큰 추출
-    private String resolveToken(HttpServletRequest httpServletRequest) {
-        String bearerToken = httpServletRequest.getHeader("Authorization");
-
-        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-
-        return null;
-    }
-
-    // Authentication 생성
-    private Authentication getAuthentication(User user) {
-        return new UsernamePasswordAuthenticationToken(user, "",
-                List.of(new SimpleGrantedAuthority(user.getRole().toString())));
-    }
+		return null;
+	}
 }

--- a/src/main/java/com/dissonance/itit/common/jwt/util/JwtUtil.java
+++ b/src/main/java/com/dissonance/itit/common/jwt/util/JwtUtil.java
@@ -1,137 +1,160 @@
 package com.dissonance.itit.common.jwt.util;
 
-import com.dissonance.itit.dto.response.GeneratedToken;
-import io.jsonwebtoken.*;
-import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import static com.dissonance.itit.domain.enums.JwtTokenExpiration.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Date;
 
-import static com.dissonance.itit.domain.enums.JwtTokenExpiration.ACCESS_TOKEN_EXPIRED_TIME;
-import static com.dissonance.itit.domain.enums.JwtTokenExpiration.REFRESH_TOKEN_EXPIRATION_TIME;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import com.dissonance.itit.domain.entity.UserDetailsImpl;
+import com.dissonance.itit.dto.response.GeneratedToken;
+import com.dissonance.itit.service.UserDetailsServiceImpl;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class JwtUtil {
-    @Value("${jwt.token.secret-key}")
-    private String jwtSecretKey;
-    private String secretKey;
+	@Value("${jwt.token.secret-key}")
+	private String jwtSecretKey;
+	private String secretKey;
 
-    // TODO: redis를 이용한 refresh token 재발급 구현
-//    private final RedisService redisService;
+	private final UserDetailsServiceImpl userDetailsService;
 
-    @PostConstruct
-    protected void init() {
-        secretKey = Base64.getEncoder().encodeToString(jwtSecretKey.getBytes(StandardCharsets.UTF_8));
-    }
+	// TODO: redis를 이용한 refresh token 재발급 구현
+	//    private final RedisService redisService;
 
-    public GeneratedToken generateToken(String email, String role) {
-        String refreshToken = generateRefreshToken(email, role);
-        String accessToken = generateAccessToken(email, role);
+	@PostConstruct
+	protected void init() {
+		secretKey = Base64.getEncoder().encodeToString(jwtSecretKey.getBytes(StandardCharsets.UTF_8));
+	}
 
-        return GeneratedToken.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .build();
-    }
+	public GeneratedToken generateToken(String email, String role) {
+		String refreshToken = generateRefreshToken(email, role);
+		String accessToken = generateAccessToken(email, role);
 
-    public String generateRefreshToken(String email, String role) {
-        // Claim에 이메일, 권한 세팅
-        Claims claims = Jwts.claims().setSubject(email);
-        claims.put("role", role);
+		return GeneratedToken.builder()
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.build();
+	}
 
-        Date now = new Date();
+	public String generateRefreshToken(String email, String role) {
+		// Claim에 이메일, 권한 세팅
+		Claims claims = Jwts.claims().setSubject(email);
+		claims.put("role", role);
 
-        return Jwts.builder()
-                .setClaims(claims)
-                .setIssuedAt(now)   // 발행일자
-                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME.getValue()))     // 만료 일시
-                .signWith(SignatureAlgorithm.HS256, secretKey)      // HS256 알고리즘과 secretKey로 서명
-                .compact();
-    }
+		Date now = new Date();
 
-    public String generateAccessToken(String email, String role) {
-        Claims claims = Jwts.claims().setSubject(email);
-        claims.put("role", role);
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(now)   // 발행일자
+			.setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME.getValue()))     // 만료 일시
+			.signWith(SignatureAlgorithm.HS256, secretKey)      // HS256 알고리즘과 secretKey로 서명
+			.compact();
+	}
 
-        Date now = new Date();
-        return
-                Jwts.builder()
-                        .setClaims(claims)
-                        .setIssuedAt(now)
-                        .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRED_TIME.getValue()))
-                        .signWith(SignatureAlgorithm.HS256, secretKey)
-                        .compact();
-    }
+	public String generateAccessToken(String email, String role) {
+		Claims claims = Jwts.claims().setSubject(email);
+		claims.put("role", role);
 
-    public boolean verifyToken(String token) {
-        try {
-//            if (redisService.getValues(token) != null && redisService.getValues(token).equals("logout")) {
-//                throw new JwtException("Invalid JWT Token - logout");
-//            }
-            Jws<Claims> claims = Jwts.parser()
-                    .setSigningKey(secretKey)
-                    .parseClaimsJws(token);
+		Date now = new Date();
+		return
+			Jwts.builder()
+				.setClaims(claims)
+				.setIssuedAt(now)
+				.setExpiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRED_TIME.getValue()))
+				.signWith(SignatureAlgorithm.HS256, secretKey)
+				.compact();
+	}
 
-            return claims.getBody()
-                    .getExpiration()
-                    .after(new Date());
-        } catch (MalformedJwtException e) {
-            log.info("Invalid JWT Token", e);
-            throw new JwtException("Invalid JWT Token", e);
-        } catch (ExpiredJwtException e) {
-            log.info("Expired JWT Token", e);
-            throw new JwtException("Expired JWT Token", e);
-        } catch (UnsupportedJwtException e) {
-            log.info("Unsupported JWT Token", e);
-            throw new JwtException("Unsupported JWT Token", e);
-        } catch (IllegalArgumentException e) {
-            log.info("JWT claims string is empty.", e);
-            throw new JwtException("JWT claims string is empty.", e);
-        }
-    }
+	public boolean verifyToken(String token) {
+		try {
+			//            if (redisService.getValues(token) != null && redisService.getValues(token).equals("logout")) {
+			//                throw new JwtException("Invalid JWT Token - logout");
+			//            }
+			Jws<Claims> claims = Jwts.parser()
+				.setSigningKey(secretKey)
+				.parseClaimsJws(token);
 
-    // 토큰에서 email 추출
-    public String getUid(String token) {
-        try {
-            return Jwts.parser()
-                    .setSigningKey(secretKey)
-                    .parseClaimsJws(token)
-                    .getBody()
-                    .getSubject();
-        } catch (ExpiredJwtException e) {
-            return e.getClaims().getSubject();
-        }
-    }
+			return claims.getBody()
+				.getExpiration()
+				.after(new Date());
+		} catch (MalformedJwtException e) {
+			log.info("Invalid JWT Token", e);
+			throw new JwtException("Invalid JWT Token", e);
+		} catch (ExpiredJwtException e) {
+			log.info("Expired JWT Token", e);
+			throw new JwtException("Expired JWT Token", e);
+		} catch (UnsupportedJwtException e) {
+			log.info("Unsupported JWT Token", e);
+			throw new JwtException("Unsupported JWT Token", e);
+		} catch (IllegalArgumentException e) {
+			log.info("JWT claims string is empty.", e);
+			throw new JwtException("JWT claims string is empty.", e);
+		}
+	}
 
-    // 토큰에서 권한 추출
-    public String getRole(String token) {
-        try {
-            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().get("role", String.class);
-        } catch (ExpiredJwtException e) {
-            return e.getClaims().get("role", String.class);
-        }
-    }
+	// 토큰에서 email 추출
+	public String getUid(String token) {
+		try {
+			return Jwts.parser()
+				.setSigningKey(secretKey)
+				.parseClaimsJws(token)
+				.getBody()
+				.getSubject();
+		} catch (ExpiredJwtException e) {
+			return e.getClaims().getSubject();
+		}
+	}
 
-    //JWT 토큰의 남은 유효 시간 추출
-    public Long getExpiration(String token){
-        Date expiration = Jwts.parser().setSigningKey(secretKey)
-                .parseClaimsJws(token).getBody().getExpiration();
+	// 토큰에서 권한 추출
+	public String getRole(String token) {
+		try {
+			return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().get("role", String.class);
+		} catch (ExpiredJwtException e) {
+			return e.getClaims().get("role", String.class);
+		}
+	}
 
-        return expiration.getTime() - new Date().getTime();
-    }
+	//JWT 토큰의 남은 유효 시간 추출
+	public Long getExpiration(String token) {
+		Date expiration = Jwts.parser().setSigningKey(secretKey)
+			.parseClaimsJws(token).getBody().getExpiration();
 
-    // request Header에서 토큰 추출
-    public String resolveToken(String requestAccessTokenInHeader) {
-        if (requestAccessTokenInHeader != null && requestAccessTokenInHeader.startsWith("Bearer ")) {
-            return requestAccessTokenInHeader.substring(7);
-        }
-        return null;
-    }
+		return expiration.getTime() - new Date().getTime();
+	}
+
+	// request Header에서 토큰 추출
+	public String resolveToken(String requestAccessTokenInHeader) {
+		if (requestAccessTokenInHeader != null && requestAccessTokenInHeader.startsWith("Bearer ")) {
+			return requestAccessTokenInHeader.substring(7);
+		}
+		return null;
+	}
+
+	// Authentication 생성
+	public Authentication getAuthentication(String accessToken) {
+		String email = getUid(accessToken);
+
+		UserDetailsImpl userDetailsImpl = userDetailsService.loadUserByUsername(email);
+
+		return new UsernamePasswordAuthenticationToken(userDetailsImpl, "", userDetailsImpl.getAuthorities());
+	}
 }

--- a/src/main/java/com/dissonance/itit/config/SecurityConfig.java
+++ b/src/main/java/com/dissonance/itit/config/SecurityConfig.java
@@ -1,11 +1,11 @@
 package com.dissonance.itit.config;
 
-import com.dissonance.itit.common.jwt.filter.JwtAuthFilter;
-import com.dissonance.itit.common.jwt.filter.JwtExceptionFilter;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -16,54 +16,57 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.List;
+import com.dissonance.itit.common.jwt.filter.JwtAuthFilter;
+import com.dissonance.itit.common.jwt.filter.JwtExceptionFilter;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig {
-    @Value("${cors.allowed-origins}")
-    String[] corsOrigins;
+	@Value("${cors.allowed-origins}")
+	String[] corsOrigins;
 
-    private final JwtAuthFilter jwtAuthFilter;
-    private final JwtExceptionFilter jwtExceptionFilter;
+	private final JwtAuthFilter jwtAuthFilter;
+	private final JwtExceptionFilter jwtExceptionFilter;
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        return http
-                .cors(corsConfig -> corsConfig.configurationSource(configurationSource()))
-                .csrf(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
-                .sessionManagement(sessionManagementConfig ->
-                        sessionManagementConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                )
-                .authorizeHttpRequests(authorizeRequests ->
-                        authorizeRequests
-                                .requestMatchers("/**",      // TODO: 토큰 관련 작업 후 security 적용
-                                        "/swagger-ui/**",
-                                        "/v3/api-docs/**").permitAll()
-                                .anyRequest().authenticated()
-                )
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtExceptionFilter, JwtAuthFilter.class)
-                .build();
-    }
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		return http
+			.cors(corsConfig -> corsConfig.configurationSource(configurationSource()))
+			.csrf(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.sessionManagement(sessionManagementConfig ->
+				sessionManagementConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			)
+			.authorizeHttpRequests(authorizeRequests ->
+				authorizeRequests
+					.requestMatchers("/oauth/**",      // TODO: 토큰 관련 작업 후 security 적용
+						"/swagger-ui/**",
+						"/v3/api-docs/**").permitAll()
+					.requestMatchers(HttpMethod.POST, "/info-posts").hasRole("ADMIN")
+					.anyRequest().authenticated()
+			)
+			.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(jwtExceptionFilter, JwtAuthFilter.class)
+			.build();
+	}
 
-    @Bean
-    public CorsConfigurationSource configurationSource() {
-        // TODO: 클라이언트 주소만 허용 예정
-        CorsConfiguration configuration = new CorsConfiguration();
+	@Bean
+	public CorsConfigurationSource configurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOriginPatterns(List.of(corsOrigins));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
-        configuration.setAllowedHeaders(List.of("*"));
-        configuration.setExposedHeaders(List.of("Access-Control-Allow-Credentials", "Authorization"));
-        configuration.setAllowCredentials(true);
-        configuration.setMaxAge(3600L);
+		configuration.setAllowedOriginPatterns(List.of(corsOrigins));
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
+		configuration.setAllowedHeaders(List.of("*"));
+		configuration.setExposedHeaders(List.of("Access-Control-Allow-Credentials", "Authorization"));
+		configuration.setAllowCredentials(true);
+		configuration.setMaxAge(3600L);
 
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
 
-        return source;
-    }
+		return source;
+	}
 }

--- a/src/main/java/com/dissonance/itit/controller/FeaturedPostContorller.java
+++ b/src/main/java/com/dissonance/itit/controller/FeaturedPostContorller.java
@@ -1,26 +1,28 @@
 package com.dissonance.itit.controller;
 
-import com.dissonance.itit.dto.response.FeaturedPostRes;
-import com.dissonance.itit.service.FeaturedPostService;
-import io.swagger.v3.oas.annotations.Operation;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import com.dissonance.itit.dto.response.FeaturedPostRes;
+import com.dissonance.itit.service.FeaturedPostService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("featured-posts")
 public class FeaturedPostContorller {
-    private final FeaturedPostService featuredPostService;
+	private final FeaturedPostService featuredPostService;
 
-    @GetMapping
-    @Operation(summary = "추천 게시글 조회", description = "운영진 추천 게시글 5개를 조회합니다.")
-    public ResponseEntity<List<FeaturedPostRes>> getFeaturedPosts() {
-        List<FeaturedPostRes> featuredPostRes = featuredPostService.getFeaturedPost();
-        return ResponseEntity.ok(featuredPostRes);
-    }
+	@GetMapping
+	@Operation(summary = "추천 게시글 조회", description = "운영진 추천 게시글 5개를 조회합니다.")
+	public ResponseEntity<List<FeaturedPostRes>> getFeaturedPosts() {
+		List<FeaturedPostRes> featuredPostRes = featuredPostService.getFeaturedPost();
+		return ResponseEntity.ok(featuredPostRes);
+	}
 }

--- a/src/main/java/com/dissonance/itit/controller/InfoPostController.java
+++ b/src/main/java/com/dissonance/itit/controller/InfoPostController.java
@@ -13,13 +13,13 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.dissonance.itit.common.annotation.CurrentUser;
 import com.dissonance.itit.domain.entity.User;
 import com.dissonance.itit.dto.request.InfoPostReq;
 import com.dissonance.itit.dto.response.InfoPostCreateRes;
 import com.dissonance.itit.dto.response.InfoPostDetailRes;
 import com.dissonance.itit.dto.response.InfoPostRes;
 import com.dissonance.itit.service.InfoPostService;
-import com.dissonance.itit.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -30,13 +30,11 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/info-posts")
 public class InfoPostController {
 	private final InfoPostService infoPostService;
-	private final UserService userService;
 
 	@PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
 	@Operation(summary = "공고 게시글 등록", description = "공고 게시글을 등록합니다.")
 	public ResponseEntity<InfoPostCreateRes> createInfoPost(@RequestPart MultipartFile imgFile,
-		@Valid @RequestPart InfoPostReq infoPostReq) {
-		User loginUser = userService.findById(1L);                // TODO: 로그인 유저 정보 적용 예정
+		@Valid @RequestPart InfoPostReq infoPostReq, @CurrentUser User loginUser) {
 		InfoPostCreateRes infoPostCreateRes = infoPostService.createInfoPost(imgFile, infoPostReq, loginUser);
 		return ResponseEntity.ok(infoPostCreateRes);
 	}

--- a/src/main/java/com/dissonance/itit/controller/OauthController.java
+++ b/src/main/java/com/dissonance/itit/controller/OauthController.java
@@ -1,27 +1,32 @@
 package com.dissonance.itit.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.dissonance.itit.dto.request.OauthTokenReq;
 import com.dissonance.itit.dto.response.GeneratedToken;
 import com.dissonance.itit.service.UserService;
+
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("oauth")
 public class OauthController {
-    private final UserService userService;
+	private final UserService userService;
 
-    // TODO: 커스텀 어노테이션으로 로그인 유저 정보 추출
-    @PostMapping("/{provider}")
-    @Operation(summary = "소셜 로그인", description = "소셜 로그인 (provider - kakao, apple)")
-    public ResponseEntity<GeneratedToken> getUserInfos(@PathVariable String provider,
-                                               @Valid @RequestBody OauthTokenReq oauthTokenReq) {
-        GeneratedToken token = userService.login(provider, oauthTokenReq.accessToken());
+	@PostMapping("/{provider}")
+	@Operation(summary = "소셜 로그인", description = "소셜 로그인 (provider - kakao, apple)")
+	public ResponseEntity<GeneratedToken> getUserInfos(@PathVariable String provider,
+		@Valid @RequestBody OauthTokenReq oauthTokenReq) {
+		GeneratedToken token = userService.login(provider, oauthTokenReq.accessToken());
 
-        return ResponseEntity.ok(token);
-    }
+		return ResponseEntity.ok(token);
+	}
 }

--- a/src/main/java/com/dissonance/itit/controller/UserController.java
+++ b/src/main/java/com/dissonance/itit/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.dissonance.itit.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dissonance.itit.common.annotation.CurrentUser;
+import com.dissonance.itit.domain.entity.User;
+import com.dissonance.itit.dto.response.LoginUserInfoRes;
+import com.dissonance.itit.service.UserService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("users")
+public class UserController {
+	private final UserService userService;
+
+	@GetMapping
+	@Operation(summary = "로그인 유저 정보", description = "로그인 유저의 관리자 여부와 소셜 로그인 provider를 제공합니다.")
+	public ResponseEntity<LoginUserInfoRes> getUserInfo(@CurrentUser User loginUser) {
+		LoginUserInfoRes userInfoRes = userService.getUserInfo(loginUser);
+
+		return ResponseEntity.ok(userInfoRes);
+	}
+}

--- a/src/main/java/com/dissonance/itit/domain/entity/UserDetailsImpl.java
+++ b/src/main/java/com/dissonance/itit/domain/entity/UserDetailsImpl.java
@@ -1,0 +1,55 @@
+package com.dissonance.itit.domain.entity;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserDetailsImpl implements UserDetails {
+	private final User user;
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		Collection<GrantedAuthority> authorities = new ArrayList<>();
+
+		authorities.add(() -> user.getRole().getKey());
+
+		return authorities;
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getEmail();
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/com/dissonance/itit/domain/enums/JwtTokenExpiration.java
+++ b/src/main/java/com/dissonance/itit/domain/enums/JwtTokenExpiration.java
@@ -6,9 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum JwtTokenExpiration {
-    ACCESS_TOKEN_EXPIRED_TIME("1시간", 1000L * 60 * 60),
-    REFRESH_TOKEN_EXPIRATION_TIME("2주", 1000L * 60 * 60 * 24 * 14);
+	ACCESS_TOKEN_EXPIRED_TIME("1시간", 1000L * 60 * 60 * 100000),      // TODO: RT 토큰 도입 후 만료 시간 적용
+	REFRESH_TOKEN_EXPIRATION_TIME("2주", 1000L * 60 * 60 * 24 * 14);
 
-    private final String description;
-    private final Long value;
+	private final String description;
+	private final Long value;
 }

--- a/src/main/java/com/dissonance/itit/dto/response/KakaoUserInformation.java
+++ b/src/main/java/com/dissonance/itit/dto/response/KakaoUserInformation.java
@@ -1,81 +1,84 @@
 package com.dissonance.itit.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Getter;
 import lombok.ToString;
 
 @ToString
 public class KakaoUserInformation implements OAuthUserInformation {
-    @JsonProperty("id")
-    private String providerId;
-    @JsonProperty("connected_at")
-    private String connectedAt;
-    @JsonProperty("properties")
-    private KakaoOAuthProperties properties;
-    @JsonProperty("kakao_account")
-    private KakaoAccount kakaoAccount;
+	@JsonProperty("id")
+	private String providerId;
+	@JsonProperty("connected_at")
+	private String connectedAt;
+	@JsonProperty("properties")
+	private KakaoOAuthProperties properties;
+	@JsonProperty("kakao_account")
+	private KakaoAccount kakaoAccount;
 
-    @Override
-    public String getNickname() {
-        return properties.getNickname();
-    }
+	@Override
+	public String getNickname() {
+		return properties.getNickname();
+	}
 
-    @Override
-    public String getProfileImgUrl() {
-        return properties.thumbnailImage != null ? properties.thumbnailImage : null;
-    }
+	@Override
+	public String getProfileImgUrl() {
+		return properties.thumbnailImage != null ? properties.thumbnailImage : null;
+	}
 
-    @Override
-    public String getProvider() {
-        return "kakao";
-    }
+	@Override
+	public String getProvider() {
+		return "kakao";
+	}
 
-    @Override
-    public String getProviderId() {
-        return providerId;
-    }
+	@Override
+	public String getProviderId() {
+		return providerId;
+	}
 
-    @Override
-    public String getEmail() {
-        return kakaoAccount.getEmail();
-    }
+	@Override
+	public String getEmail() {
+		return kakaoAccount.getEmail();
+	}
 
-    @ToString
-    @Getter
-    static class KakaoOAuthProperties {
-        @JsonProperty("nickname")
-        private String nickname;
-        @JsonProperty("profile_image")
-        private String profileImage;
-        @JsonProperty("thumbnail_image")
-        private String thumbnailImage;
-    }
+	@ToString
+	@Getter
+	static class KakaoOAuthProperties {
+		@JsonProperty("nickname")
+		private String nickname;
+		@JsonProperty("profile_image")
+		private String profileImage;
+		@JsonProperty("thumbnail_image")
+		private String thumbnailImage;
+	}
 
-    @ToString
-    @Getter
-    static class KakaoAccount {
-        @JsonProperty(value = "email")
-        private String email;
-        @JsonProperty(value = "profile_image_needs_agreement")
-        private Boolean profileImageNeedsAgreement;
-        @JsonProperty(value = "profile_nickname_needs_agreement")
-        private Boolean profileNicknameNeedsAgreement;
-        @JsonProperty(value = "profile")
-        private Profile profile;
-    }
+	@ToString
+	@Getter
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	static class KakaoAccount {
+		@JsonProperty(value = "email")
+		private String email;
+		@JsonProperty(value = "profile_image_needs_agreement")
+		private Boolean profileImageNeedsAgreement;
+		@JsonProperty(value = "profile_nickname_needs_agreement")
+		private Boolean profileNicknameNeedsAgreement;
+		@JsonProperty(value = "profile")
+		private Profile profile;
+	}
 
-    @ToString
-    @Getter
-    static class Profile {
-        @JsonProperty("nickname")
-        private String nickname;
-        @JsonProperty("profile_image_url")
-        private String profileImage;
-        @JsonProperty("thumbnail_image_url")
-        private String thumbnailImage;
-        @JsonProperty("is_default_image")
-        private Boolean isDefaultImage;
-        @JsonProperty("is_default_nickname")
-        private Boolean isDefaultNickname;
-    }
+	@ToString
+	@Getter
+	static class Profile {
+		@JsonProperty("nickname")
+		private String nickname;
+		@JsonProperty("profile_image_url")
+		private String profileImage;
+		@JsonProperty("thumbnail_image_url")
+		private String thumbnailImage;
+		@JsonProperty("is_default_image")
+		private Boolean isDefaultImage;
+		@JsonProperty("is_default_nickname")
+		private Boolean isDefaultNickname;
+	}
 }

--- a/src/main/java/com/dissonance/itit/dto/response/LoginUserInfoRes.java
+++ b/src/main/java/com/dissonance/itit/dto/response/LoginUserInfoRes.java
@@ -1,0 +1,6 @@
+package com.dissonance.itit.dto.response;
+
+public record LoginUserInfoRes(
+	boolean isAdmin,
+	String provider) {
+}

--- a/src/main/java/com/dissonance/itit/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/dissonance/itit/service/UserDetailsServiceImpl.java
@@ -1,0 +1,31 @@
+package com.dissonance.itit.service;
+
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.dissonance.itit.common.exception.CustomException;
+import com.dissonance.itit.common.exception.ErrorCode;
+import com.dissonance.itit.domain.entity.User;
+import com.dissonance.itit.domain.entity.UserDetailsImpl;
+import com.dissonance.itit.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetailsImpl loadUserByUsername(String email) throws UsernameNotFoundException {
+		User findUser = userRepository.findByEmail(email)
+			.orElseThrow(() -> new CustomException(ErrorCode.NON_EXISTENT_EMAIL));
+
+		if (findUser != null) {
+			return new UserDetailsImpl(findUser);
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/com/dissonance/itit/service/UserService.java
+++ b/src/main/java/com/dissonance/itit/service/UserService.java
@@ -1,72 +1,77 @@
 package com.dissonance.itit.service;
 
-import com.dissonance.itit.common.exception.CustomException;
-import com.dissonance.itit.common.exception.ErrorCode;
-import com.dissonance.itit.common.jwt.util.JwtUtil;
-import com.dissonance.itit.domain.enums.Role;
-import com.dissonance.itit.domain.entity.User;
-import com.dissonance.itit.dto.response.GeneratedToken;
-import com.dissonance.itit.dto.response.OAuthUserInformation;
-import com.dissonance.itit.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.dissonance.itit.common.exception.CustomException;
+import com.dissonance.itit.common.exception.ErrorCode;
+import com.dissonance.itit.common.jwt.util.JwtUtil;
+import com.dissonance.itit.domain.entity.User;
+import com.dissonance.itit.domain.enums.Role;
+import com.dissonance.itit.dto.response.GeneratedToken;
+import com.dissonance.itit.dto.response.LoginUserInfoRes;
+import com.dissonance.itit.dto.response.OAuthUserInformation;
+import com.dissonance.itit.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class UserService {
-    private final OauthService oauthService;
-    private final UserRepository userRepository;
-    private final JwtUtil jwtUtil;
+	private final OauthService oauthService;
+	private final UserRepository userRepository;
+	private final JwtUtil jwtUtil;
 
-    @Transactional
-    public GeneratedToken login(String provider, String token) {
-        OAuthUserInformation userInformation;
+	@Transactional
+	public GeneratedToken login(String provider, String token) {
+		OAuthUserInformation userInformation;
 
-        if (provider.equals("kakao")) {
-            userInformation = oauthService.requestUserInformation(token);
-        } else {
-            log.info("존재하지 않는 provider: " + provider);
-            throw new CustomException(ErrorCode.INVALID_PROVIDER);
-        }
+		if (provider.equals("kakao")) {
+			userInformation = oauthService.requestUserInformation(token);
+		} else {
+			log.info("존재하지 않는 provider: " + provider);
+			throw new CustomException(ErrorCode.INVALID_PROVIDER);
+		}
 
-        User user;
+		User user;
 
-        if (userRepository.existsByProviderAndProviderId(provider, userInformation.getProviderId())) {
-            log.info("[UserService] login, response: {}", userInformation);
+		if (userRepository.existsByProviderAndProviderId(provider, userInformation.getProviderId())) {
+			log.info("[UserService] login, response: {}", userInformation);
 
-            user = findByEmail(userInformation.getEmail());
+			user = findByEmail(userInformation.getEmail());
 
-        } else {
-            log.info("[UserService] signUp, response: {}", userInformation);
+		} else {
+			log.info("[UserService] signUp, response: {}", userInformation);
 
-            user = User.builder()
-                    .email(userInformation.getEmail())
-                    .password("kakao")
-                    .name(userInformation.getNickname())
-                    .provider(userInformation.getProvider())
-                    .providerId(userInformation.getProviderId())
-                    .profileImgUrl(userInformation.getProfileImgUrl())
-                    .role(Role.USER)
-                    .build();
+			user = User.builder()
+				.email(userInformation.getEmail())
+				.password("kakao")
+				.name(userInformation.getNickname())
+				.provider(userInformation.getProvider())
+				.providerId(userInformation.getProviderId())
+				.profileImgUrl(userInformation.getProfileImgUrl())
+				.role(Role.USER)
+				.build();
 
-            userRepository.save(user);
-        }
+			userRepository.save(user);
+		}
 
-        return jwtUtil.generateToken(user.getEmail(), user.getRole().getKey());
-    }
+		return jwtUtil.generateToken(user.getEmail(), user.getRole().getKey());
+	}
 
-    private User findByEmail(String email) {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new CustomException(ErrorCode.NON_EXISTENT_EMAIL));
-    }
+	private User findByEmail(String email) {
+		return userRepository.findByEmail(email)
+			.orElseThrow(() -> new CustomException(ErrorCode.NON_EXISTENT_EMAIL));
+	}
 
-    @Transactional(readOnly = true)
-    public User findById(Long id) {
-        return userRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.NON_EXISTENT_USER_ID));
-    }
+	@Transactional(readOnly = true)
+	public LoginUserInfoRes getUserInfo(User loginUser) {
+		return new LoginUserInfoRes(isAdmin(loginUser), loginUser.getProvider());
+	}
+
+	private boolean isAdmin(User loginUser) {
+		return loginUser.getRole().equals(Role.ADMIN);
+	}
 }


### PR DESCRIPTION
**이슈 번호**
- #19 

**작업 내용**
- jwt token filter 수정 → security context를 이용해 custom userDetails를 반환하도록 세팅
- CORS 처리 → iOS는 CORS 관련 처리를 하지 않음
- security filter chain 활성화
  - 공고 게시글 생성은 관리자만 요청 허용
  - 로그인 이외의 api는 인증된 사용자만 요청 가능 
- AT로 로그인 유저 정보를 가져오는 기능 구현
- 관리자 여부 확인 API 구현
  - admin 여부, oauth provider 
- access token 유효시간 연장 → refresh token 관련 처리가 이루어질 때까지만 무기한으로 연장
