### PR TITLE
Feature/itds-44 mypage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 def QDomains = []

--- a/src/main/java/com/dissonance/itit/common/exception/ErrorCode.java
+++ b/src/main/java/com/dissonance/itit/common/exception/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
 	INVALID_APPLE_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않는 Apple Token입니다."),
 	INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 JSON 형식입니다."),
 
+	// 403
+	UNAUTHORIZED_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "권한없는 Refresh Token입니다."),
+
 	// 404
 	NON_EXISTENT_USER_ID(HttpStatus.NOT_FOUND, "해당 id의 사용자가 존재하지 않습니다."),
 	NON_EXISTENT_EMAIL(HttpStatus.NOT_FOUND, "해당 email의 사용자가 존재하지 않습니다."),

--- a/src/main/java/com/dissonance/itit/common/jwt/util/JwtUtil.java
+++ b/src/main/java/com/dissonance/itit/common/jwt/util/JwtUtil.java
@@ -45,7 +45,7 @@ public class JwtUtil {
 	}
 
 	public GeneratedToken generateToken(String email, String role) {
-		String refreshToken = generateRefreshToken(email, role);
+		String refreshToken = generateRefreshToken();
 		String accessToken = generateAccessToken(email, role);
 
 		redisService.setValuesWithTimeout(email, refreshToken, REFRESH_TOKEN_EXPIRATION_TIME.getValue());
@@ -56,15 +56,10 @@ public class JwtUtil {
 			.build();
 	}
 
-	public String generateRefreshToken(String email, String role) {
-		// Claim에 이메일, 권한 세팅
-		Claims claims = Jwts.claims().setSubject(email);
-		claims.put("role", role);
-
+	public String generateRefreshToken() {
 		Date now = new Date();
 
 		return Jwts.builder()
-			.setClaims(claims)
 			.setIssuedAt(now)   // 발행일자
 			.setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME.getValue()))     // 만료 일시
 			.signWith(SignatureAlgorithm.HS256, secretKey)      // HS256 알고리즘과 secretKey로 서명

--- a/src/main/java/com/dissonance/itit/config/RedisConfig.java
+++ b/src/main/java/com/dissonance/itit/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.dissonance.itit.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+	@Value("${spring.data.redis.host}")
+	private String host;
+	@Value("${spring.data.redis.port}")
+	private Integer port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+}

--- a/src/main/java/com/dissonance/itit/controller/UserController.java
+++ b/src/main/java/com/dissonance/itit/controller/UserController.java
@@ -1,12 +1,17 @@
 package com.dissonance.itit.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dissonance.itit.common.annotation.CurrentUser;
 import com.dissonance.itit.common.util.ApiResponse;
 import com.dissonance.itit.domain.entity.User;
+import com.dissonance.itit.dto.request.RefreshTokenReq;
+import com.dissonance.itit.dto.response.GeneratedToken;
 import com.dissonance.itit.dto.response.LoginUserInfoRes;
 import com.dissonance.itit.service.UserService;
 
@@ -25,5 +30,23 @@ public class UserController {
 		LoginUserInfoRes userInfoRes = userService.getUserInfo(loginUser);
 
 		return ApiResponse.success(userInfoRes);
+	}
+
+	@PostMapping("reissue")
+	@Operation(summary = "토큰 재발급", description = "access token과 refresh token을 재발급합니다.")
+	public ApiResponse<GeneratedToken> reissue(@RequestHeader("Authorization") String requestAccessToken,
+		@RequestBody RefreshTokenReq tokenRequest) {
+		GeneratedToken reissuedToken = userService.accessTokenByRefreshToken(requestAccessToken,
+			tokenRequest.refreshToken());
+
+		return ApiResponse.success(reissuedToken);
+	}
+
+	@GetMapping("/logout")
+	@Operation(summary = "로그아웃", description = "access token을 만료시킵니다.")
+	public ApiResponse<String> logout(@RequestHeader("Authorization") String requestAccessToken) {
+		userService.logout(requestAccessToken);
+
+		return ApiResponse.success("logout success");
 	}
 }

--- a/src/main/java/com/dissonance/itit/controller/UserController.java
+++ b/src/main/java/com/dissonance/itit/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.dissonance.itit.controller;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -47,6 +48,14 @@ public class UserController {
 	public ApiResponse<String> logout(@RequestHeader("Authorization") String requestAccessToken) {
 		userService.logout(requestAccessToken);
 
-		return ApiResponse.success("logout success");
+		return ApiResponse.success("로그아웃되었습니다.");
+	}
+
+	@DeleteMapping
+	@Operation(summary = "회원 탈퇴", description = "로그인 유저의 계정을 탈퇴시킵니다.")
+	public ApiResponse<String> withdraw(@CurrentUser User loginUser) {
+		userService.withdraw(loginUser.getId());
+
+		return ApiResponse.success("회원 탈퇴가 완료되었습니다.");
 	}
 }

--- a/src/main/java/com/dissonance/itit/domain/enums/JwtTokenExpiration.java
+++ b/src/main/java/com/dissonance/itit/domain/enums/JwtTokenExpiration.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum JwtTokenExpiration {
-	ACCESS_TOKEN_EXPIRED_TIME("1시간", 1000L * 60 * 60 * 100000),      // TODO: RT 토큰 도입 후 만료 시간 적용
+	ACCESS_TOKEN_EXPIRED_TIME("1시간", 1000L * 60 * 60),
 	REFRESH_TOKEN_EXPIRATION_TIME("2주", 1000L * 60 * 60 * 24 * 14);
 
 	private final String description;

--- a/src/main/java/com/dissonance/itit/dto/request/RefreshTokenReq.java
+++ b/src/main/java/com/dissonance/itit/dto/request/RefreshTokenReq.java
@@ -1,0 +1,6 @@
+package com.dissonance.itit.dto.request;
+
+public record RefreshTokenReq(
+	String refreshToken
+) {
+}

--- a/src/main/java/com/dissonance/itit/service/RedisService.java
+++ b/src/main/java/com/dissonance/itit/service/RedisService.java
@@ -1,0 +1,26 @@
+package com.dissonance.itit.service;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class RedisService {
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public String getValues(String key) {
+		return redisTemplate.opsForValue().get(key);
+	}
+
+	public void setValuesWithTimeout(String key, String value, long duration) {
+		redisTemplate.opsForValue().set(key, value, duration, TimeUnit.MILLISECONDS);
+	}
+
+	public void deleteValues(String key) {
+		redisTemplate.delete(key);
+	}
+}

--- a/src/main/java/com/dissonance/itit/service/UserService.java
+++ b/src/main/java/com/dissonance/itit/service/UserService.java
@@ -108,4 +108,9 @@ public class UserService {
 		redisService.setValuesWithTimeout(accessToken, "logout", time);
 		redisService.deleteValues(uid);
 	}
+
+	@Transactional
+	public void withdraw(Long loginUserId) {
+		userRepository.deleteById(loginUserId);
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,10 @@ spring:
     multipart:
       max-request-size: 10MB
       max-file-size: 10MB
+  data:
+    redis:
+      port: ${REDIS_PORT}
+      host: ${REDIS_HOST}
 
 jwt:
   token:


### PR DESCRIPTION
**이슈 번호**
- #26 

**작업 내용**
- 로그아웃 api
  - 로그아웃 처리된 access token 사용 불가
- 회원탈퇴 api
  - 탈퇴 시, user와 연관 관계가 있는 게시글, 신고 로그 null로 설정
- access token 재발급 api
  - access token 만료 시간 1시간으로 재설정
  - 상대적으로 만료 시간이 긴 refresh token에 담긴 사용자 정보 삭제
