### PR TITLE
Feature/itds-65 update featured post

### DIFF
--- a/src/main/java/com/dissonance/itit/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/dissonance/itit/global/common/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 	IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 id의 이미지가 존재하지 않습니다."),
 	NON_EXISTENT_CATEGORY_ID(HttpStatus.NOT_FOUND, "해당 id의 카테고리가 존재하지 않습니다."),
 	NON_EXISTENT_INFO_POST_ID(HttpStatus.NOT_FOUND, "해당 id의 공고 게시글이 존재하지 않습니다."),
+	NON_EXISTENT_FEATURED_INFO_POST_ID(HttpStatus.NOT_FOUND, "해당 id의 추천 공고 게시글이 존재하지 않습니다."),
 
 	// 500
 	IO_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "파일 입출력 에러"),

--- a/src/main/java/com/dissonance/itit/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/dissonance/itit/global/common/exception/ErrorCode.java
@@ -14,6 +14,9 @@ public enum ErrorCode {
 	INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 변환에 실패했습니다."),
 	INVALID_APPLE_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않는 Apple Token입니다."),
 	INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 JSON 형식입니다."),
+	INVALID_SEARCH_KEYWORD_LENGTH(HttpStatus.BAD_REQUEST, "검색어는 2자 이상 100자 이하로 입력해야 합니다."),
+	INVALID_SEARCH_KEYWORD_SPECIAL_CHAR(HttpStatus.BAD_REQUEST, "검색어에 허용되지 않는 특수문자가 포함되어 있습니다."),
+	INVALID_SEARCH_KEYWORD_SQL_INJECTION(HttpStatus.BAD_REQUEST, "검색어에 사용할 수 없는 예약어가 포함되어 있습니다."),
 
 	// 403
 	UNAUTHORIZED_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "권한없는 Refresh Token입니다."),

--- a/src/main/java/com/dissonance/itit/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/dissonance/itit/global/common/exception/ErrorCode.java
@@ -32,7 +32,11 @@ public enum ErrorCode {
 
 	// 500
 	IO_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "파일 입출력 에러"),
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러"),
+	POST_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "DB 오류로 게시글 생성에 실패했습니다."),
+
+	// 503
+	IMAGE_UPDATE_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "이미지 서버가 일시적으로 요청을 처리할 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/dissonance/itit/global/common/util/SearchValidator.java
+++ b/src/main/java/com/dissonance/itit/global/common/util/SearchValidator.java
@@ -1,0 +1,43 @@
+package com.dissonance.itit.global.common.util;
+
+import static org.springframework.util.StringUtils.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import com.dissonance.itit.global.common.exception.CustomException;
+import com.dissonance.itit.global.common.exception.ErrorCode;
+
+public class SearchValidator {
+	// 허용할 특수문자 패턴 (공백, 하이픈, 언더스코어만 허용)
+	private static final Pattern ALLOWED_CHARS =
+		Pattern.compile("^[가-힣a-zA-Z0-9\\s\\-_]+$");
+
+	// SQL Injection 위험이 있는 키워드들
+	private static final List<String> SQL_INJECTION_PATTERNS = Arrays.asList(
+		"SELECT", "INSERT", "UPDATE", "DELETE", "DROP",
+		"UNION", "INTO", "FROM", "WHERE", "--", "/*",
+		"*", "*/", ";", "OR", "AND"
+	);
+
+	public static void validateSearchKeyword(String keyword) {
+		// 1. 기본 길이 검증
+		if (!hasText(keyword) || keyword.length() < 2 || keyword.length() > 100) {
+			throw new CustomException(ErrorCode.INVALID_SEARCH_KEYWORD_LENGTH);
+		}
+
+		// 2. 특수문자 검증
+		if (!ALLOWED_CHARS.matcher(keyword).matches()) {
+			throw new CustomException(ErrorCode.INVALID_SEARCH_KEYWORD_SPECIAL_CHAR);
+		}
+
+		// 3. SQL Injection 패턴 검증
+		String upperKeyword = keyword.toUpperCase();
+		for (String pattern : SQL_INJECTION_PATTERNS) {
+			if (upperKeyword.contains(pattern)) {
+				throw new CustomException(ErrorCode.INVALID_SEARCH_KEYWORD_SQL_INJECTION);
+			}
+		}
+	}
+}

--- a/src/main/java/com/dissonance/itit/global/config/SecurityConfig.java
+++ b/src/main/java/com/dissonance/itit/global/config/SecurityConfig.java
@@ -48,8 +48,9 @@ public class SecurityConfig {
 						"/swagger-ui/**",
 						"/v3/api-docs/**",
 						"/info-posts/**",
-						"/featured-posts/**").permitAll()
+						"/featured-posts").permitAll()
 					.requestMatchers("/admin/info-posts/**").hasRole("ADMIN")
+					.requestMatchers(HttpMethod.PUT, "/featured-posts/{featuredPostId}/**").hasRole("ADMIN")
 					.requestMatchers(HttpMethod.PATCH, "/info-posts/{infoPostId}/reports").authenticated()
 					.anyRequest().authenticated()
 			)

--- a/src/main/java/com/dissonance/itit/image/domain/Directory.java
+++ b/src/main/java/com/dissonance/itit/image/domain/Directory.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum Directory {
-	INFORMATION("info-posts"), RECRUITMENT("recruit-posts");
+	INFORMATION("info-posts"),
+	RECRUITMENT("recruit-posts"),
+	FEATURE("featured-posts");
 
 	private final String name;
 }

--- a/src/main/java/com/dissonance/itit/image/service/ImageService.java
+++ b/src/main/java/com/dissonance/itit/image/service/ImageService.java
@@ -120,9 +120,12 @@ public class ImageService {
 	 */
 	@Transactional
 	public void delete(Image image) {
-		amazonS3Client.deleteObject(bucket, image.getDirectory().getName() + "/" + image.getConvertImageName());
-
-		imageRepository.deleteById(image.getId());
+		try {
+			amazonS3Client.deleteObject(bucket, image.getDirectory().getName() + "/" + image.getConvertImageName());
+			imageRepository.deleteById(image.getId());
+		} catch (Exception e) {
+			log.error("이미지 삭제 실패. 이미지 ID: {}", image.getId(), e);
+		}
 	}
 
 	/**

--- a/src/main/java/com/dissonance/itit/image/service/ImageService.java
+++ b/src/main/java/com/dissonance/itit/image/service/ImageService.java
@@ -73,6 +73,28 @@ public class ImageService {
 		}
 	}
 
+	@Transactional
+	public String uploadAndGetImgPath(Directory directory, MultipartFile multipartFile) {
+		validateImage(multipartFile.getContentType());
+
+		String fileName = createFileName(multipartFile.getOriginalFilename(), directory.getName());
+
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+
+		objectMetadata.setContentLength(multipartFile.getSize());
+
+		objectMetadata.setContentType(multipartFile.getContentType());
+
+		try (InputStream inputStream = multipartFile.getInputStream()) {
+			amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+				.withCannedAcl(CannedAccessControlList.PublicRead));
+
+			return amazonS3Client.getUrl(bucket, fileName).toString();
+		} catch (IOException e) {
+			throw new CustomException(IO_EXCEPTION);
+		}
+	}
+
 	/**
 	 * 주어진 콘텐츠 타입이 이미지 파일인지 검증합니다.
 	 *

--- a/src/main/java/com/dissonance/itit/image/service/ImageService.java
+++ b/src/main/java/com/dissonance/itit/image/service/ImageService.java
@@ -19,6 +19,7 @@ import com.dissonance.itit.global.common.exception.CustomException;
 import com.dissonance.itit.image.domain.Directory;
 import com.dissonance.itit.image.domain.Image;
 import com.dissonance.itit.image.repository.ImageRepository;
+import com.dissonance.itit.post.domain.InfoPost;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -93,6 +94,12 @@ public class ImageService {
 		} catch (IOException e) {
 			throw new CustomException(IO_EXCEPTION);
 		}
+	}
+
+	@Transactional
+	public Image updateImage(MultipartFile imgFile, InfoPost infoPost) {
+		delete(infoPost.getImage());
+		return upload(Directory.INFORMATION, imgFile);
 	}
 
 	/**

--- a/src/main/java/com/dissonance/itit/post/controller/AdminInfoPostController.java
+++ b/src/main/java/com/dissonance/itit/post/controller/AdminInfoPostController.java
@@ -13,12 +13,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.dissonance.itit.global.common.annotation.CurrentUser;
 import com.dissonance.itit.global.common.util.ApiResponse;
-import com.dissonance.itit.user.domain.User;
 import com.dissonance.itit.post.dto.request.InfoPostReq;
 import com.dissonance.itit.post.dto.response.InfoPostCreateRes;
 import com.dissonance.itit.post.dto.response.InfoPostDetailRes;
 import com.dissonance.itit.post.dto.response.InfoPostUpdateRes;
-import com.dissonance.itit.post.service.InfoPostService;
+import com.dissonance.itit.post.service.InfoPostFacade;
+import com.dissonance.itit.user.domain.User;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -28,27 +28,27 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/admin/info-posts")
 public class AdminInfoPostController {
-	private final InfoPostService infoPostService;
+	private final InfoPostFacade infoPostFacade;
 
 	@PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
 	@Operation(summary = "공고 게시글 등록", description = "공고 게시글을 등록합니다.")
 	public ApiResponse<InfoPostCreateRes> createInfoPost(@RequestPart MultipartFile imgFile,
 		@Valid @RequestPart InfoPostReq infoPostReq, @CurrentUser User loginUser) {
-		InfoPostCreateRes infoPostCreateRes = infoPostService.createInfoPost(imgFile, infoPostReq, loginUser);
+		InfoPostCreateRes infoPostCreateRes = infoPostFacade.createInfoPost(imgFile, infoPostReq, loginUser);
 		return ApiResponse.success(infoPostCreateRes);
 	}
 
 	@DeleteMapping("/{infoPostId}")
 	@Operation(summary = "공고 게시글 삭제", description = "공고 게시글을 삭제합니다.")
 	public ApiResponse<String> deleteInfoPost(@PathVariable Long infoPostId) {
-		infoPostService.deleteInfoPostById(infoPostId);
+		infoPostFacade.deleteInfoPostById(infoPostId);
 		return ApiResponse.success("게시글 삭제 성공");
 	}
 
 	@GetMapping("/{infoPostId}")
 	@Operation(summary = "공고 수정 - 게시글 조회", description = "공고 게시글 수정 페이지에 띄울 상세 정보를 조회합니다.")
 	public ApiResponse<InfoPostUpdateRes> getInfoPostDetailByIdForUpdate(@PathVariable Long infoPostId) {
-		InfoPostUpdateRes infoPostUpdateRes = infoPostService.getInfoPostDetailByIdForUpdate(infoPostId);
+		InfoPostUpdateRes infoPostUpdateRes = infoPostFacade.getInfoPostDetailByIdForUpdate(infoPostId);
 		return ApiResponse.success(infoPostUpdateRes);
 	}
 
@@ -58,8 +58,9 @@ public class AdminInfoPostController {
 	public ApiResponse<InfoPostDetailRes> updateInfoPost(@PathVariable Long infoPostId,
 		@RequestPart(required = false) MultipartFile imgFile,
 		@Valid @RequestPart InfoPostReq infoPostReq, @CurrentUser User loginUser) {
-		InfoPostDetailRes infoPostDetailRes = infoPostService.updateInfoPost(infoPostId, imgFile, infoPostReq,
+		InfoPostDetailRes infoPostDetailRes = infoPostFacade.updateInfoPostAndImg(infoPostId, imgFile, infoPostReq,
 			loginUser);
+
 		return ApiResponse.success(infoPostDetailRes);
 	}
 }

--- a/src/main/java/com/dissonance/itit/post/controller/FeaturedPostContorller.java
+++ b/src/main/java/com/dissonance/itit/post/controller/FeaturedPostContorller.java
@@ -33,9 +33,7 @@ public class FeaturedPostContorller {
 		return ApiResponse.success(featuredPostRes);
 	}
 
-	// TODO: 관리자 권한만 수정 권한 있도록
-	@PutMapping(value = "{featuredPostId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
-		MediaType.APPLICATION_JSON_VALUE})
+	@PutMapping(value = "{featuredPostId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@Operation(summary = "추천 게시글 수정", description = "추천 게시글을 수정합니다.")
 	public ApiResponse<FeaturedPostRes> updateFeaturedPost(@PathVariable Integer featuredPostId,
 		@RequestPart MultipartFile imgFile, @RequestParam Long infoPostId) {

--- a/src/main/java/com/dissonance/itit/post/controller/FeaturedPostContorller.java
+++ b/src/main/java/com/dissonance/itit/post/controller/FeaturedPostContorller.java
@@ -2,9 +2,15 @@ package com.dissonance.itit.post.controller;
 
 import java.util.List;
 
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.dissonance.itit.global.common.util.ApiResponse;
 import com.dissonance.itit.post.dto.response.FeaturedPostRes;
@@ -23,6 +29,17 @@ public class FeaturedPostContorller {
 	@Operation(summary = "추천 게시글 조회", description = "운영진 추천 게시글 5개를 조회합니다.")
 	public ApiResponse<List<FeaturedPostRes>> getFeaturedPosts() {
 		List<FeaturedPostRes> featuredPostRes = featuredPostService.getFeaturedPost();
+
+		return ApiResponse.success(featuredPostRes);
+	}
+
+	// TODO: 관리자 권한만 수정 권한 있도록
+	@PutMapping(value = "{featuredPostId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
+		MediaType.APPLICATION_JSON_VALUE})
+	@Operation(summary = "추천 게시글 수정", description = "추천 게시글을 수정합니다.")
+	public ApiResponse<FeaturedPostRes> updateFeaturedPost(@PathVariable Integer featuredPostId,
+		@RequestPart MultipartFile imgFile, @RequestParam Long infoPostId) {
+		FeaturedPostRes featuredPostRes = featuredPostService.updateFeaturedPost(featuredPostId, imgFile, infoPostId);
 
 		return ApiResponse.success(featuredPostRes);
 	}

--- a/src/main/java/com/dissonance/itit/post/domain/FeaturedPost.java
+++ b/src/main/java/com/dissonance/itit/post/domain/FeaturedPost.java
@@ -1,9 +1,22 @@
 package com.dissonance.itit.post.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
@@ -25,4 +38,9 @@ public class FeaturedPost {
 	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
 	@JoinColumn(name = "info_post_id")
 	private InfoPost infoPost;
+
+	public void update(InfoPost infoPost, String bannerImageUrl) {
+		this.infoPost = infoPost;
+		this.bannerImageUrl = bannerImageUrl;
+	}
 }

--- a/src/main/java/com/dissonance/itit/post/domain/InfoPost.java
+++ b/src/main/java/com/dissonance/itit/post/domain/InfoPost.java
@@ -105,4 +105,8 @@ public class InfoPost extends BaseTime {
 	public boolean isAuthor(User loginUser) {
 		return this.getAuthor().getId().equals(loginUser.getId());
 	}
+
+	public void updateImage(Image image) {
+		this.image = image;
+	}
 }

--- a/src/main/java/com/dissonance/itit/post/domain/InfoPost.java
+++ b/src/main/java/com/dissonance/itit/post/domain/InfoPost.java
@@ -90,10 +90,6 @@ public class InfoPost extends BaseTime {
 	@JoinColumn(name = "category_id")
 	private Category category;
 
-	public void updateImage(Image newImage) {
-		this.image = newImage;
-	}
-
 	public void update(InfoPostUpdateReq updateReq) {
 		this.category = updateReq.category();
 		this.title = updateReq.title();

--- a/src/main/java/com/dissonance/itit/post/dto/response/FeaturedPostRes.java
+++ b/src/main/java/com/dissonance/itit/post/dto/response/FeaturedPostRes.java
@@ -1,12 +1,12 @@
 package com.dissonance.itit.post.dto.response;
 
+import java.util.List;
+
 import com.dissonance.itit.post.domain.FeaturedPost;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.List;
 
 @Getter
 @Builder
@@ -26,5 +26,13 @@ public class FeaturedPostRes {
 				.infoPostId(featuredPost.getInfoPost().getId())
 				.build())
 			.toList();
+	}
+
+	public static FeaturedPostRes of(FeaturedPost featuredPost) {
+		return FeaturedPostRes.builder()
+			.featuredPostId(featuredPost.getId())
+			.bannerImageUrl(featuredPost.getBannerImageUrl())
+			.infoPostId(featuredPost.getInfoPost().getId())
+			.build();
 	}
 }

--- a/src/main/java/com/dissonance/itit/post/repository/InfoPostRepository.java
+++ b/src/main/java/com/dissonance/itit/post/repository/InfoPostRepository.java
@@ -1,8 +1,14 @@
 package com.dissonance.itit.post.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
+import com.dissonance.itit.image.domain.Image;
 import com.dissonance.itit.post.domain.InfoPost;
 
 public interface InfoPostRepository extends JpaRepository<InfoPost, Long> {
+	@Modifying
+	@Query("update InfoPost ip set ip.image=:image where ip.id=:infoPostId")
+	void updateImage(Long infoPostId, Image image);
 }

--- a/src/main/java/com/dissonance/itit/post/service/FeaturedPostService.java
+++ b/src/main/java/com/dissonance/itit/post/service/FeaturedPostService.java
@@ -4,8 +4,14 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.dissonance.itit.global.common.exception.CustomException;
+import com.dissonance.itit.global.common.exception.ErrorCode;
+import com.dissonance.itit.image.domain.Directory;
+import com.dissonance.itit.image.service.ImageService;
 import com.dissonance.itit.post.domain.FeaturedPost;
+import com.dissonance.itit.post.domain.InfoPost;
 import com.dissonance.itit.post.dto.response.FeaturedPostRes;
 import com.dissonance.itit.post.repository.FeaturedPostRepository;
 
@@ -15,10 +21,31 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FeaturedPostService {
 	private final FeaturedPostRepository featuredPostRepository;
+	private final InfoPostService infoPostService;
+	private final ImageService imageService;
 
 	@Transactional(readOnly = true)
 	public List<FeaturedPostRes> getFeaturedPost() {
 		List<FeaturedPost> featuredPosts = featuredPostRepository.findAll();
 		return FeaturedPostRes.of(featuredPosts);
+	}
+
+	@Transactional
+	public FeaturedPostRes updateFeaturedPost(Integer featuredPostId, MultipartFile imgFile, Long infoPostId) {
+		FeaturedPost featuredPost = findById(featuredPostId);
+
+		InfoPost infoPost = infoPostService.findById(infoPostId);
+
+		String bannerImgUrl = imageService.uploadAndGetImgPath(Directory.INFORMATION, imgFile);
+
+		featuredPost.update(infoPost, bannerImgUrl);
+
+		return FeaturedPostRes.of(featuredPost);
+	}
+
+	@Transactional(readOnly = true)
+	public FeaturedPost findById(Integer id) {
+		return featuredPostRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.NON_EXISTENT_FEATURED_INFO_POST_ID));
 	}
 }

--- a/src/main/java/com/dissonance/itit/post/service/FeaturedPostService.java
+++ b/src/main/java/com/dissonance/itit/post/service/FeaturedPostService.java
@@ -33,10 +33,10 @@ public class FeaturedPostService {
 	@Transactional
 	public FeaturedPostRes updateFeaturedPost(Integer featuredPostId, MultipartFile imgFile, Long infoPostId) {
 		FeaturedPost featuredPost = findById(featuredPostId);
-
 		InfoPost infoPost = infoPostService.findById(infoPostId);
 
-		String bannerImgUrl = imageService.uploadAndGetImgPath(Directory.INFORMATION, imgFile);
+		// TODO: Image 객체 매핑으로 변경
+		String bannerImgUrl = imageService.uploadAndGetImgPath(Directory.FEATURE, imgFile);
 
 		featuredPost.update(infoPost, bannerImgUrl);
 

--- a/src/main/java/com/dissonance/itit/post/service/InfoPostFacade.java
+++ b/src/main/java/com/dissonance/itit/post/service/InfoPostFacade.java
@@ -28,6 +28,7 @@ public class InfoPostFacade {
 	private final InfoPostService infoPostService;
 	private final RecruitmentPositionService recruitmentPositionService;
 
+	@Transactional
 	public InfoPostDetailRes updateInfoPostAndImg(Long infoPostId, MultipartFile imgFile, InfoPostReq infoPostReq,
 		User loginUser) {
 		// 1. DB 작업: 게시글 필드 업데이트
@@ -41,7 +42,7 @@ public class InfoPostFacade {
 				Image newImage = imageService.upload(Directory.INFORMATION, imgFile);
 
 				// DB에 이미지 정보 반영
-				infoPostService.updateImage(infoPost, newImage);
+				infoPost.updateImage(newImage);
 
 				// 이전 이미지 삭제는 DB 업데이트 후 처리
 				imageService.delete(oldImage);

--- a/src/main/java/com/dissonance/itit/post/service/InfoPostFacade.java
+++ b/src/main/java/com/dissonance/itit/post/service/InfoPostFacade.java
@@ -1,0 +1,67 @@
+package com.dissonance.itit.post.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.dissonance.itit.image.domain.Directory;
+import com.dissonance.itit.image.domain.Image;
+import com.dissonance.itit.image.service.ImageService;
+import com.dissonance.itit.post.domain.InfoPost;
+import com.dissonance.itit.post.dto.request.InfoPostReq;
+import com.dissonance.itit.post.dto.response.InfoPostCreateRes;
+import com.dissonance.itit.post.dto.response.InfoPostDetailRes;
+import com.dissonance.itit.post.dto.response.InfoPostUpdateRes;
+import com.dissonance.itit.recruitmentPosition.service.RecruitmentPositionService;
+import com.dissonance.itit.user.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class InfoPostFacade {
+	private final ImageService imageService;
+	private final InfoPostService infoPostService;
+	private final RecruitmentPositionService recruitmentPositionService;
+
+	@Transactional
+	public InfoPostDetailRes updateInfoPostAndImg(Long infoPostId, MultipartFile imgFile, InfoPostReq infoPostReq,
+		User loginUser) {
+		InfoPost infoPost = infoPostService.updateInfoPostFields(infoPostId, infoPostReq, loginUser);
+		List<String> positionInfos = recruitmentPositionService.findPositionInfosByInfoPostId(infoPostId);
+
+		if (imgFile != null) {
+			Image uploadedImage = imageService.updateImage(imgFile, infoPost);
+			infoPost.updateImage(uploadedImage);
+		}
+
+		return InfoPostDetailRes.of(infoPost, positionInfos);
+	}
+
+	@Transactional
+	public InfoPostCreateRes createInfoPost(MultipartFile imgFile, InfoPostReq infoPostReq, User author) {
+		Image image = imageService.upload(Directory.INFORMATION, imgFile);
+
+		InfoPost infoPost = infoPostService.saveInfoPost(infoPostReq, author, image);
+
+		recruitmentPositionService.addPositions(infoPost, infoPostReq.positionInfos());
+
+		return InfoPostCreateRes.of(infoPost);
+	}
+
+	@Transactional
+	public void deleteInfoPostById(Long infoPostId) {
+		InfoPost infoPost = infoPostService.findById(infoPostId);
+
+		imageService.delete(infoPost.getImage());
+
+		infoPostService.deleteInfoPostById(infoPostId);
+	}
+
+	@Transactional(readOnly = true)
+	public InfoPostUpdateRes getInfoPostDetailByIdForUpdate(Long infoPostId) {
+		return infoPostService.getInfoPostDetailByIdForUpdate(infoPostId);
+	}
+}

--- a/src/main/java/com/dissonance/itit/post/service/InfoPostService.java
+++ b/src/main/java/com/dissonance/itit/post/service/InfoPostService.java
@@ -118,4 +118,9 @@ public class InfoPostService {
 
 		return infoPostRepositorySupport.findInfoPostsByKeyword(keyword, pageable);
 	}
+
+	@Transactional
+	public void updateImage(InfoPost infoPost, Image image) {
+		infoPostRepository.updateImage(infoPost.getId(), image);
+	}
 }

--- a/src/main/java/com/dissonance/itit/post/service/InfoPostService.java
+++ b/src/main/java/com/dissonance/itit/post/service/InfoPostService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.dissonance.itit.global.common.exception.CustomException;
 import com.dissonance.itit.global.common.exception.ErrorCode;
+import com.dissonance.itit.global.common.util.SearchValidator;
 import com.dissonance.itit.image.domain.Image;
 import com.dissonance.itit.post.domain.Category;
 import com.dissonance.itit.post.domain.InfoPost;
@@ -113,6 +114,8 @@ public class InfoPostService {
 
 	@Transactional(readOnly = true)
 	public Page<InfoPostRes> getInfoPostsByKeyword(String keyword, Pageable pageable) {
+		SearchValidator.validateSearchKeyword(keyword);
+
 		return infoPostRepositorySupport.findInfoPostsByKeyword(keyword, pageable);
 	}
 }

--- a/src/main/java/com/dissonance/itit/post/service/InfoPostService.java
+++ b/src/main/java/com/dissonance/itit/post/service/InfoPostService.java
@@ -6,18 +6,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.dissonance.itit.global.common.exception.CustomException;
 import com.dissonance.itit.global.common.exception.ErrorCode;
-import com.dissonance.itit.image.domain.Directory;
 import com.dissonance.itit.image.domain.Image;
-import com.dissonance.itit.image.service.ImageService;
 import com.dissonance.itit.post.domain.Category;
 import com.dissonance.itit.post.domain.InfoPost;
 import com.dissonance.itit.post.dto.request.InfoPostReq;
 import com.dissonance.itit.post.dto.request.InfoPostUpdateReq;
-import com.dissonance.itit.post.dto.response.InfoPostCreateRes;
 import com.dissonance.itit.post.dto.response.InfoPostDetailRes;
 import com.dissonance.itit.post.dto.response.InfoPostDetailRes.InfoPostInfo;
 import com.dissonance.itit.post.dto.response.InfoPostRes;
@@ -35,20 +31,14 @@ public class InfoPostService {
 	private final InfoPostRepository infoPostRepository;
 	private final InfoPostRepositorySupport infoPostRepositorySupport;
 
-	private final ImageService imageService;
 	private final CategoryService categoryService;
 	private final RecruitmentPositionService recruitmentPositionService;
 
 	@Transactional
-	public InfoPostCreateRes createInfoPost(MultipartFile imgFile, InfoPostReq infoPostReq, User author) {
-		Image image = imageService.upload(Directory.INFORMATION, imgFile);
+	public InfoPost saveInfoPost(InfoPostReq infoPostReq, User author, Image image) {
 		Category category = categoryService.findById(infoPostReq.categoryId());
 
-		InfoPost infoPost = infoPostRepository.save(infoPostReq.toEntity(image, author, category));
-
-		recruitmentPositionService.addPositions(infoPost, infoPostReq.positionInfos());
-
-		return InfoPostCreateRes.of(infoPost);
+		return infoPostRepository.save(infoPostReq.toEntity(image, author, category));
 	}
 
 	@Transactional(readOnly = true)
@@ -77,12 +67,10 @@ public class InfoPostService {
 
 	@Transactional
 	public void deleteInfoPostById(Long infoPostId) {
-		InfoPost infoPost = findById(infoPostId);
-		imageService.delete(infoPost.getImage());
-
 		infoPostRepository.deleteById(infoPostId);
 	}
 
+	@Transactional(readOnly = true)
 	public InfoPostUpdateRes getInfoPostDetailByIdForUpdate(Long infoPostId) {
 		InfoPostUpdateRes.InfoPostInfo infoPostInfo = infoPostRepositorySupport.findInfoPostDetailsForUpdate(
 			infoPostId);
@@ -98,8 +86,9 @@ public class InfoPostService {
 	}
 
 	@Transactional
-	public InfoPostDetailRes updateInfoPost(Long infoPostId, MultipartFile imgFile, InfoPostReq infoPostReq,
+	public InfoPost updateInfoPostFields(Long infoPostId, InfoPostReq infoPostReq,
 		User loginUser) {
+
 		InfoPost infoPost = findById(infoPostId);
 
 		validateAuthor(infoPost, loginUser);
@@ -112,16 +101,8 @@ public class InfoPostService {
 		infoPost.update(updateReq);
 
 		recruitmentPositionService.updatePositions(infoPost, infoPostReq.positionInfos());
-		List<String> positionInfos = recruitmentPositionService.findPositionInfosByInfoPostId(infoPostId);
 
-		// TODO: S3 Transaction 처리 (데이터 정합성)
-		if (imgFile != null && !imgFile.isEmpty()) {
-			imageService.delete(infoPost.getImage());
-			Image newImage = imageService.upload(Directory.INFORMATION, imgFile);
-			infoPost.updateImage(newImage);
-		}
-
-		return InfoPostDetailRes.of(infoPost, positionInfos);
+		return infoPost;
 	}
 
 	private void validateAuthor(InfoPost infoPost, User loginUser) {

--- a/src/main/java/com/dissonance/itit/post/service/InfoPostService.java
+++ b/src/main/java/com/dissonance/itit/post/service/InfoPostService.java
@@ -118,9 +118,4 @@ public class InfoPostService {
 
 		return infoPostRepositorySupport.findInfoPostsByKeyword(keyword, pageable);
 	}
-
-	@Transactional
-	public void updateImage(InfoPost infoPost, Image image) {
-		infoPostRepository.updateImage(infoPost.getId(), image);
-	}
 }

--- a/src/main/java/com/dissonance/itit/recruitmentPosition/service/RecruitmentPositionService.java
+++ b/src/main/java/com/dissonance/itit/recruitmentPosition/service/RecruitmentPositionService.java
@@ -30,6 +30,7 @@ public class RecruitmentPositionService {
 		recruitmentPositionRepository.saveAll(recruitmentPositions);
 	}
 
+	@Transactional(readOnly = true)
 	public List<String> findPositionInfosByInfoPostId(Long infoPostId) {
 		return recruitmentPositionRepositorySupport.findByInfoPostId(infoPostId);
 	}

--- a/src/test/java/com/dissonance/itit/fixture/TestFixture.java
+++ b/src/test/java/com/dissonance/itit/fixture/TestFixture.java
@@ -56,6 +56,7 @@ public class TestFixture {
 	public static Image createImage() {
 		return Image.builder()
 			.id(5L)
+			.imageUrl("www.image.com")
 			.build();
 	}
 
@@ -83,6 +84,16 @@ public class TestFixture {
 			.image(image)
 			.category(category)
 			.author(author)
+			.build();
+	}
+
+	public static InfoPost createInfoPostWithoutImage() {
+		return InfoPost.builder()
+			.id(10L)
+			.title("Post 10")
+			.image(createImage())
+			.author(createUser())
+			.category(createCategory())
 			.build();
 	}
 

--- a/src/test/java/com/dissonance/itit/service/InfoPostFacadeTest.java
+++ b/src/test/java/com/dissonance/itit/service/InfoPostFacadeTest.java
@@ -1,0 +1,151 @@
+package com.dissonance.itit.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.dissonance.itit.fixture.TestFixture;
+import com.dissonance.itit.image.domain.Directory;
+import com.dissonance.itit.image.domain.Image;
+import com.dissonance.itit.image.service.ImageService;
+import com.dissonance.itit.post.domain.InfoPost;
+import com.dissonance.itit.post.dto.request.InfoPostReq;
+import com.dissonance.itit.post.dto.response.InfoPostCreateRes;
+import com.dissonance.itit.post.dto.response.InfoPostDetailRes;
+import com.dissonance.itit.post.dto.response.InfoPostUpdateRes;
+import com.dissonance.itit.post.service.InfoPostFacade;
+import com.dissonance.itit.post.service.InfoPostService;
+import com.dissonance.itit.recruitmentPosition.service.RecruitmentPositionService;
+import com.dissonance.itit.user.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+public class InfoPostFacadeTest {
+	@InjectMocks
+	private InfoPostFacade infoPostFacade;
+
+	@Mock
+	private ImageService imageService;
+	@Mock
+	private InfoPostService infoPostService;
+	@Mock
+	private RecruitmentPositionService recruitmentPositionService;
+
+	@Test
+	@DisplayName("공고 수정 성공 (이미지 포함)")
+	void updateInfoPostAndImg_withImage_returnInfoPostDetailRes() {
+		// given
+		Long infoPostId = 1L;
+		MultipartFile imgFile = mock(MultipartFile.class);
+		InfoPostReq infoPostReq = TestFixture.createInfoPostReq();
+		User loginUser = TestFixture.createUser();
+		Image uploadedImage = TestFixture.createImage();
+		InfoPost infoPost = TestFixture.createInfoPostWithImage(uploadedImage);
+		List<String> positionInfos = TestFixture.createMultiplePositionInfos();
+
+		given(infoPostService.updateInfoPostFields(infoPostId, infoPostReq, loginUser)).willReturn(infoPost);
+		given(recruitmentPositionService.findPositionInfosByInfoPostId(infoPostId)).willReturn(positionInfos);
+		given(imageService.updateImage(imgFile, infoPost)).willReturn(uploadedImage);
+
+		// when
+		InfoPostDetailRes result = infoPostFacade.updateInfoPostAndImg(infoPostId, imgFile, infoPostReq, loginUser);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(infoPost.getImage()).isEqualTo(uploadedImage);
+		verify(infoPostService).updateInfoPostFields(infoPostId, infoPostReq, loginUser);
+		verify(recruitmentPositionService).findPositionInfosByInfoPostId(infoPostId);
+		verify(imageService).updateImage(imgFile, infoPost);
+	}
+
+	@Test
+	@DisplayName("공고 수정 성공 (이미지 미포함)")
+	void updateInfoPostAndImg_withoutImage_returnInfoPostDetailRes() {
+		// given
+		Long infoPostId = 1L;
+		InfoPostReq infoPostReq = TestFixture.createInfoPostReq();
+		User loginUser = TestFixture.createUser();
+		InfoPost infoPost = TestFixture.createInfoPostWithoutImage();
+		List<String> positionInfos = TestFixture.createMultiplePositionInfos();
+
+		given(infoPostService.updateInfoPostFields(infoPostId, infoPostReq, loginUser)).willReturn(infoPost);
+		given(recruitmentPositionService.findPositionInfosByInfoPostId(infoPostId)).willReturn(positionInfos);
+
+		// when
+		InfoPostDetailRes result = infoPostFacade.updateInfoPostAndImg(infoPostId, null, infoPostReq, loginUser);
+
+		// then
+		assertThat(result).isNotNull();
+		verify(infoPostService).updateInfoPostFields(infoPostId, infoPostReq, loginUser);
+		verify(recruitmentPositionService).findPositionInfosByInfoPostId(infoPostId);
+		verify(imageService, never()).updateImage(any(), any());
+	}
+
+	@Test
+	@DisplayName("공고 생성 성공")
+	void createInfoPost_returnInfoPostCreateRes() {
+		// given
+		MultipartFile imgFile = mock(MultipartFile.class);
+		InfoPostReq infoPostReq = TestFixture.createInfoPostReq();
+		User author = TestFixture.createUser();
+		Image image = TestFixture.createImage();
+		InfoPost infoPost = TestFixture.createInfoPostWithImage(image);
+
+		given(imageService.upload(Directory.INFORMATION, imgFile)).willReturn(image);
+		given(infoPostService.saveInfoPost(infoPostReq, author, image)).willReturn(infoPost);
+		// given(infoPostReq.positionInfos()).willReturn(TestFixture.createMultiplePositionInfos());
+
+		// when
+		InfoPostCreateRes result = infoPostFacade.createInfoPost(imgFile, infoPostReq, author);
+
+		// then
+		assertThat(result).isNotNull();
+		verify(imageService).upload(Directory.INFORMATION, imgFile);
+		verify(infoPostService).saveInfoPost(infoPostReq, author, image);
+		verify(recruitmentPositionService).addPositions(infoPost, infoPostReq.positionInfos());
+	}
+
+	@Test
+	@DisplayName("공고 삭제 성공")
+	void deleteInfoPostById_success() {
+		// given
+		Long infoPostId = 1L;
+		Image image = TestFixture.createImage();
+		InfoPost infoPost = TestFixture.createInfoPostWithImage(image);
+
+		given(infoPostService.findById(infoPostId)).willReturn(infoPost);
+
+		// when
+		infoPostFacade.deleteInfoPostById(infoPostId);
+
+		// then
+		verify(infoPostService).findById(infoPostId);
+		verify(imageService).delete(image);
+		verify(infoPostService).deleteInfoPostById(infoPostId);
+	}
+
+	@Test
+	@DisplayName("수정을 위한 공고 상세 조회 성공")
+	void getInfoPostDetailByIdForUpdate_returnInfoPostUpdateRes() {
+		// given
+		Long infoPostId = 1L;
+		InfoPostUpdateRes expectedRes = mock(InfoPostUpdateRes.class);
+
+		given(infoPostService.getInfoPostDetailByIdForUpdate(infoPostId)).willReturn(expectedRes);
+
+		// when
+		InfoPostUpdateRes result = infoPostFacade.getInfoPostDetailByIdForUpdate(infoPostId);
+
+		// then
+		assertThat(result).isEqualTo(expectedRes);
+		verify(infoPostService).getInfoPostDetailByIdForUpdate(infoPostId);
+	}
+}


### PR DESCRIPTION
**이슈 번호**
- #43 

**작업 내용**
- 추천 공고 수정 api 개발
- 검색 키워드 유효성 검사 custom validator 추가
- 공고 api 리팩토링
  - s3 서비스 관련해서 발생하는 exception 예외처리 추가
  - 공고 생성시, DB 트랜잭션과 S3 업로드 트랜잭션을 분리 -> 이미지 업로드 후 DB 오류 발생 시, 업로드된 이미지 삭제 처리
  - 공고 업로드시, 중간에 이미지 업로드가 실패하면 DB 롤백됨. 해당 사항을 고려하여 S3 버킷의 이미지 삭제는 제일 하단에 배치

**TODO**
- 추천 공고 수정 기능 추가로, 이미지 업로드 기능 필요 -> featured_post와 image를 1:1 매핑으로 변경하여 upload 메서드 재활용